### PR TITLE
fix warning for html_static_path entry 

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -88,7 +88,7 @@ html_theme = 'alabaster'
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
+#html_static_path = ['_static']
 
 # Custom sidebar templates, must be a dictionary that maps document names
 # to template names.


### PR DESCRIPTION
This is a fix for the warning appearing during build. 
WARNING: html_static_path entry '/home/bms-doc/_static' does not exist
We don't need static files yet, so I commented out the entry in config.